### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,10 +81,10 @@ jobs:
           dotnet-version: 6.0.x
 
       - name: install docfx
-        run: dotnet tool update -g docfx --version "3.0.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
+        run: dotnet tool update -g docfx --version "2.77.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
 
       - name: run docfx
-        run: docfx build --dry-run
+        run: docfx build --dryRun --warningsAsErrors
 
   semantic-conventions:
     runs-on: ubuntu-latest

--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://github\\.com/Contrast-Security-Inc/secobs-semantic-conventions/(issues|pull)"
+    },
+    {
+      "pattern": "https://osi-model\\.com/.*"
     }
   ],
   "replacementPatterns": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,8 @@ See:
 Markdown files should be properly formatted before a pull request is sent out.
 In this repository we follow the
 [markdownlint rules](https://github.com/DavidAnson/markdownlint#rules--aliases)
-with some customizations. See [markdownlint](.markdownlint.yaml) or
-[settings](.vscode/settings.json) for details.
+with some customizations. See [markdownlint](/.markdownlint.yaml) or
+[settings](/.vscode/settings.json) for details.
 
 We highly encourage to use line breaks in markdown files at `80` characters
 wide. There are tools that can do it for you effectively. Please submit proposal
@@ -162,8 +162,8 @@ make misspell-correction
 A PR (pull request) is considered to be **ready to merge** when:
 
 - It has received at least two approvals from the [code
-  owners](./.github/CODEOWNERS)
-- There is no `request changes` from the [code owners](./.github/CODEOWNERS).
+  owners](/.github/CODEOWNERS)
+- There is no `request changes` from the [code owners](/.github/CODEOWNERS).
 
 ## Updating the referenced specification version
 

--- a/docfx.json
+++ b/docfx.json
@@ -1,7 +1,10 @@
 {
-  "files": "**/*.{md,png}",
-  "warningsAsErrors": true,
-  "rules": {
-    "link-out-of-scope": "off"
+  "build": {
+    "content": [
+      {"files": "**/*.md"}
+    ],
+    "resource": [
+      {"files":  "**/*.png"}
+    ]
   }
 }

--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -207,15 +207,15 @@ Note that `network.local.*` attributes are not included in these examples since 
 
 ###### Simple client/server example
 
-![simple.png](simple.png)
+![simple.png](/docs/general/simple.png "Simple")
 
 ###### Client/server example with reverse proxy
 
-![reverse-proxy.png](reverse-proxy.png)
+![reverse-proxy.png](/docs/general/reverse-proxy.png "Reverse Proxy")
 
 ###### Client/server example with forward proxy
 
-![forward-proxy.png](forward-proxy.png)
+![forward-proxy.png](/docs/general/forward-proxy.png "Forward Proxy")
 
 ## General remote service attributes
 


### PR DESCRIPTION
Two elements of the pipeline have started failing on their own since it was last run;

- [DocFX v3 has been removed from public availability](https://github.com/dotnet/docfx/issues/9901#issuecomment-2105764170), and therefore needs downdating before that task will function properly again.
- The `markdown-link-check` task has started failing because a website referenced throughout this spec (https://osi-model.com/) has an expired license. We need to configure to somehow ignore this.
